### PR TITLE
Avoid warning from DESTROY when filename isn't writable.

### DIFF
--- a/lib/Log/Dispatch/FileRotate.pm
+++ b/lib/Log/Dispatch/FileRotate.pm
@@ -389,7 +389,7 @@ sub DESTROY
 
 	# Clean up locks
 	close $self->{lfh} if $self->{lfh};
- 	unlink $self->{lf} if -f $self->{lf};
+ 	unlink $self->{lf} if $self->{lf} && -f $self->{lf};
 }
 
 sub logit

--- a/t/file-open-failure.t
+++ b/t/file-open-failure.t
@@ -1,0 +1,44 @@
+#!/usr/bin/env perl -w
+#
+# Test case for what happens when filename cannot be written to
+#
+
+use strict;
+use warnings;
+use Test::More 0.88;
+use Path::Tiny 0.018;
+use Test::Warn;
+
+use_ok 'Log::Dispatch::FileRotate';
+
+my $tempdir = Path::Tiny->tempdir;
+
+# Create a file that isn't writable
+my $filename = $tempdir->child('myerrs.log')->stringify;
+open my $o, '>', $filename;
+close $o;
+chmod 0, $filename;
+
+warning_is(
+    sub {
+        my $file_logger = eval {
+            Log::Dispatch::FileRotate->new(
+                filename    => $filename,
+                min_level   => 'debug',
+                mode        => 'append',
+                max         => 5,
+                newline     => 0,
+                DatePattern => 'YYYY-dd-HH');
+        };
+
+        like(
+            $@,
+            qr/Cannot write to '.*myerrs.log': Permission denied/,
+            'Expect a "Permission denied" error'
+        );
+    },
+    undef,
+    'No warnings from using an unwritable filename'
+);
+
+done_testing;


### PR DESCRIPTION
If filename wasn't writable, an exception was thrown, but also a
warning from sub DESTROY:

Use of uninitialized value in -f at ../lib/Log/Dispatch/FileRotate.pm line 392.

Avoid that.

Also added a test case for this.