### PR TITLE
Fix lockfile race condition test in Strawberry Perl (AppVeyor)

### DIFF
--- a/xt/author/lockfile-race-condition.t
+++ b/xt/author/lockfile-race-condition.t
@@ -72,7 +72,7 @@ sub run_processes {
         if ($msg =~ /got lock/ or $msg =~ /releasing/) {
             # strip off dates and pid numbers from front of message
             $msg = substr($msg, 25);
-            $msg =~ s/^[0-9]+ //;
+            $msg =~ s/^-?[0-9]+ //;
 
             # save in the warnings file
             print $warnfh $msg;


### PR DESCRIPTION
Message doesn't seem to be stripped completely of unneeded stuff under
Strawberry Perl.

This change lets this dist build successfully in Strawberry Perl under AppVeyor; see e.g. https://ci.appveyor.com/project/zakame/perl-log-dispatch-filerotate/build/1.0.26/job/qx7q40yb0rt5v3no

This PR is also a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/february.html).