### PR TITLE
Skip file open failure on cygwin

### DIFF
--- a/t/file-open-failure.t
+++ b/t/file-open-failure.t
@@ -16,6 +16,10 @@ unless (eval { require POSIX; 1 }) {
     plan skip_all => 'POSIX module is required for this test';
 }
 
+if ($^O eq 'cygwin') {
+    plan skip_all => 'chmod behavior varies on cygwin';
+}
+
 if ($> == 0) {
     plan skip_all => 'root user is exempt from file RW permissions restrictions';
 }


### PR DESCRIPTION
`chmod` has varying behavior on cygwin depending on the underlying
filesystem, see https://cygwin.com/cygwin-ug-net/using-filemodes.html

This PR is also a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/february.html).