### PR TITLE
`use_ok` tests in its own script

### DIFF
--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -1,0 +1,13 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use Test::More 0.88;
+
+use_ok $_ for qw(
+    Log::Dispatch::FileRotate
+    Log::Dispatch::FileRotate::Flock
+    Log::Dispatch::FileRotate::Mutex
+);
+
+done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -10,10 +10,10 @@ if ($^O eq 'cygwin') {
     $ENV{TZ} = (split " ",(`date`)[0])[4];
 }
 
-use_ok 'Log::Dispatch';
-use_ok 'Log::Dispatch::Screen';
-use_ok 'Log::Dispatch::FileRotate';
-use_ok 'Date::Manip';
+use Log::Dispatch;
+use Log::Dispatch::Screen;
+use Log::Dispatch::FileRotate;
+use Date::Manip;
 
 my $tz;
 eval {

--- a/t/file-open-failure.t
+++ b/t/file-open-failure.t
@@ -30,7 +30,7 @@ unless ($curloc eq $locale) {
     plan skip_all => "locale $locale is not available on this system";
 }
 
-use_ok 'Log::Dispatch::FileRotate';
+use Log::Dispatch::FileRotate;
 
 my $tempdir = Path::Tiny->tempdir;
 

--- a/t/lockfile-open-failure.t
+++ b/t/lockfile-open-failure.t
@@ -14,8 +14,8 @@ if ($> == 0) {
     plan skip_all => 'root user is exempt from file RW permissions restrictions';
 }
 
-use_ok 'Log::Dispatch';
-use_ok 'Log::Dispatch::FileRotate';
+use Log::Dispatch;
+use Log::Dispatch::FileRotate;
 
 my $tempdir = Path::Tiny->tempdir;
 

--- a/t/no-activity-bug.t
+++ b/t/no-activity-bug.t
@@ -5,10 +5,10 @@ use warnings;
 use Test::More 0.88;
 use Path::Tiny 0.018;
 
-plan tests => 7;
+plan tests => 5;
 
-use_ok 'Log::Dispatch';
-use_ok 'Log::Dispatch::FileRotate';
+use Log::Dispatch;
+use Log::Dispatch::FileRotate;
 
 my $tempdir = Path::Tiny->tempdir;
 

--- a/t/sig-warn-deadlock.t
+++ b/t/sig-warn-deadlock.t
@@ -19,10 +19,10 @@ if ($] < 5.008000) {
     plan skip_all => 'This test requires Perl 5.8.0 or later';
 }
 
-plan tests => 10;
+plan tests => 8;
 
-use_ok 'Log::Dispatch';
-use_ok 'Log::Dispatch::FileRotate';
+use Log::Dispatch;
+use Log::Dispatch::FileRotate;
 
 my $tempdir = Path::Tiny->tempdir;
 my $logfile = $tempdir->child('myerrs.log')->stringify;

--- a/t/size-with-underscore.t
+++ b/t/size-with-underscore.t
@@ -5,8 +5,8 @@ use warnings;
 use Test::More 0.88;
 use Path::Tiny 0.018;
 
-use_ok 'Log::Dispatch';
-use_ok 'Log::Dispatch::FileRotate';
+use Log::Dispatch;
+use Log::Dispatch::FileRotate;
 
 my $tempdir = Path::Tiny->tempdir;
 

--- a/xt/author/lockfile-race-condition.t
+++ b/xt/author/lockfile-race-condition.t
@@ -22,9 +22,9 @@ else {
     waitpid $pid, 0;
 }
 
-plan tests => 2;
+plan tests => 1;
 
-use_ok 'Log::Dispatch::FileRotate' or exit 1;
+use Log::Dispatch::FileRotate;
 
 shim_logit_delay();
 


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/february.html).

Building on #13, this moves `use_ok` tests to its own test script, so that it can fail early (the new test runs before others,) and it can try to avoid issues using certain modules like Date::Manip having special initialization.